### PR TITLE
PoC mock java.time.Instant

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -6,6 +6,7 @@ import framework.{BaseController, ControllerComponents}
 import org.jobrunr.scheduling.JobRequestScheduler
 import play.api.mvc.AnyContent
 
+import java.time.Instant
 import javax.inject.*
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -18,6 +19,7 @@ class HomeController @Inject() (
     extends BaseController(cc) {
 
   def index(): play.api.mvc.Action[AnyContent] = async() { implicit req =>
+    println("In controller: " + Instant.now())
     req.loggedInUserOpt.foreach { loggedInUser =>
       jobScheduler.enqueue(TestIncrementDummyCounterWorkerRequest(loggedInUser.id))
     }

--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ libraryDependencies ++= Seq(
   "io.github.tanin47" %% "play3-json-form" % "1.2.0",
   "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test,
   "de.leanovate.play-mockws" %% "play-mockws-3-0" % "3.1.0" % Test,
+  "org.mockito" % "mockito-core" % "5.20.0" % Test,
   "org.playframework" %% "play-slick" % "6.2.0",
   "org.playframework" %% "play-slick-evolutions" % "6.2.0",
   "com.github.tminglei" %% "slick-pg" % "0.23.1",

--- a/test/browsers/HomeSpec.scala
+++ b/test/browsers/HomeSpec.scala
@@ -1,9 +1,18 @@
 package browsers
 
 import controllers.routes
+import org.mockito.Mockito
+import org.mockito.Mockito.{mockStatic, when}
+
+import java.time.{Clock, Instant}
 
 class HomeSpec extends Base {
   it("tests running the background job") {
+    val fixedInstant = Instant.parse("2024-11-01T10:00:00Z")
+    val mockedInstant = mockStatic(classOf[Instant], Mockito.CALLS_REAL_METHODS)
+    when(Instant.now()).thenReturn(fixedInstant)
+    println("In test: " + Instant.now())
+
     var user = makeUser(email = "test@test.com", password = Some("1234"))
     user.dummyCounter should be(0)
 
@@ -14,5 +23,8 @@ class HomeSpec extends Base {
 
     user = await(userService.getById(user.id)).get
     user.dummyCounter should be(1)
+
+    val now = Instant.now()
+    now should be(fixedInstant)
   }
 }


### PR DESCRIPTION
The mocked time doesn't work in the controller because Mockito only supports mocking static methods that run on the same thread. 

The controller is running in a PlayFramework server, which is on a different thread.